### PR TITLE
Remove LogoJump (No longer exists, redirects to phishing/malware)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ All services require 501c3 determination letter unless otherwise indicated.
   - Canva for work features for up to 10 team members
 * [Kuvio Creative](https://www.kuv.io/)
   - 30% off website design and development services
-* [LogoJump](https://logojump.com/)
-  - Custom human made logos. 80% off on any package 
 * [Piktochart](https://piktochart.com/pricing/nonprofit/)
   - Piktochart offers discounted package for non-profit organizations at 14% of its yearly original price, both on the personal and the team plan.  
 


### PR DESCRIPTION
LogoJump doesn't appear to exist anymore, and the provided link redirects to phishing/malware popup sites. 